### PR TITLE
Add MultiMerge.2026 project for Visual Studio 2026 support

### DIFF
--- a/MultiMerge.2022/MultiMerge.Package.cs
+++ b/MultiMerge.2022/MultiMerge.Package.cs
@@ -65,7 +65,7 @@ namespace MultiMerge
         /// </summary>
         protected override async System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            base.Initialize();
+            await base.InitializeAsync(cancellationToken, progress);
             // Switches to the UI thread in order to consume some services used in command initialization
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
@@ -100,13 +100,34 @@ namespace MultiMerge
         /// </summary>
         private void MergeByComment(object sender, EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             var teamExplorer = GetService(typeof(ITeamExplorer)) as ITeamExplorer;
             // Must be connected to a TFS server to do this
             DTE2 automationObject = (DTE2)GetService(typeof(DTE));
             var versionControl = automationObject.GetObject("Microsoft.VisualStudio.TeamFoundation.VersionControl.VersionControlExt") as VersionControlExt;
+            if (versionControl == null)
+            {
+                System.Windows.Forms.MessageBox.Show(
+                    "Team Foundation version control is not available in this Visual Studio session. Open a solution under TFVC and ensure the Azure DevOps / TFVC workload is installed.",
+                    "MultiMerge",
+                    System.Windows.Forms.MessageBoxButtons.OK,
+                    System.Windows.Forms.MessageBoxIcon.Warning);
+                return;
+            }
             var logger = new OutputWindowLogger(this);
-            frmMerge findForm = new frmMerge(versionControl, teamExplorer, logger);
-            findForm.Show();
+            try
+            {
+                var findForm = new frmMerge(versionControl, teamExplorer, logger, automationObject);
+                findForm.Show();
+            }
+            catch (InvalidOperationException ex)
+            {
+                System.Windows.Forms.MessageBox.Show(
+                    ex.Message,
+                    "MultiMerge",
+                    System.Windows.Forms.MessageBoxButtons.OK,
+                    System.Windows.Forms.MessageBoxIcon.Warning);
+            }
         }
 
         /// <summary>
@@ -116,7 +137,7 @@ namespace MultiMerge
         /// </summary>
         private void MergeFromHistoryWindow(object sender, EventArgs e)
         {
-
+            ThreadHelper.ThrowIfNotOnUIThread();
             // Must be connected to a TFS server to do this
             DTE2 automationObject = (DTE2)GetService(typeof(DTE));
 
@@ -125,6 +146,8 @@ namespace MultiMerge
                 var logger = new OutputWindowLogger(this);
 
                 VersionControlExt versionControlExt = automationObject.GetObject("Microsoft.VisualStudio.TeamFoundation.VersionControl.VersionControlExt") as VersionControlExt;
+                if (versionControlExt == null)
+                    return;
                 //get History window
                 var window = versionControlExt?.History?.ActiveWindow;
                 if (window != null)
@@ -159,6 +182,7 @@ namespace MultiMerge
 
         private void UnShelveToBranch(object sender, EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             try
             {
                 var logger = new OutputWindowLogger(this);
@@ -211,6 +235,8 @@ namespace MultiMerge
             if (automationObject != null)
             {
                 VersionControlExt versionControlExt = automationObject.GetObject("Microsoft.VisualStudio.TeamFoundation.VersionControl.VersionControlExt") as VersionControlExt;
+                if (versionControlExt?.Explorer?.CurrentFolderItem == null)
+                    return;
                 var localpath = versionControlExt.Explorer.CurrentFolderItem.LocalPath;
                 if (!string.IsNullOrEmpty(localpath))
                 {

--- a/MultiMerge.2022/frmMerge.cs
+++ b/MultiMerge.2022/frmMerge.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using EnvDTE80;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.VisualStudio.TeamFoundation.VersionControl;
 
@@ -19,7 +20,7 @@ namespace MultiMerge
             
         }
 
-        public frmMerge(VersionControlExt versionControl, ITeamExplorer teamExplorer, ILogger logger) : base(versionControl, teamExplorer, logger)
+        public frmMerge(VersionControlExt versionControl, ITeamExplorer teamExplorer, ILogger logger, DTE2 dte = null) : base(versionControl, teamExplorer, logger, dte)
         {}
 
         public frmMerge(VersionControlExt versionControl, ITeamExplorer teamExplorer, ILogger logger,

--- a/MultiMerge.2026/MultiMerge.2026.csproj
+++ b/MultiMerge.2026/MultiMerge.2026.csproj
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <_MultiMergeVsRoot>$(VSInstallRoot)</_MultiMergeVsRoot>
+    <_MultiMergeVsRoot Condition="'$(_MultiMergeVsRoot)' == '' And '$(DevEnvDir)' != ''">$([System.IO.Path]::GetFullPath('$(DevEnvDir)..\..'))</_MultiMergeVsRoot>
+    <_MultiMergeVsRoot Condition="'$(_MultiMergeVsRoot)' == '' And '$(VSINSTALLDIR)' != ''">$([System.IO.Path]::GetFullPath('$(VSINSTALLDIR)'))</_MultiMergeVsRoot>
+    <_MultiMergeVsRoot Condition="'$(_MultiMergeVsRoot)' != '' And !HasTrailingSlash('$(_MultiMergeVsRoot)')">$(_MultiMergeVsRoot)\</_MultiMergeVsRoot>
+    <MultiMergeTeamExplorerSdkDir Condition="'$(_MultiMergeVsRoot)' != ''">$(_MultiMergeVsRoot)Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\</MultiMergeTeamExplorerSdkDir>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="Exists('$(MultiMergeTeamExplorerSdkDir)Microsoft.VisualStudio.TeamFoundation.VersionControl.dll')">
+      <PropertyGroup>
+        <MultiMergeTfShellFromHost>true</MultiMergeTfShellFromHost>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <MultiMergeTfShellFromHost>false</MultiMergeTfShellFromHost>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <PropertyGroup>
+    <MultiMergeTfShellHintPath Condition="'$(MultiMergeTfShellFromHost)' == 'true'">$(MultiMergeTeamExplorerSdkDir)</MultiMergeTfShellHintPath>
+    <MultiMergeTfShellHintPath Condition="'$(MultiMergeTfShellFromHost)' != 'true'">$(MSBuildThisFileDirectory)Assemblies\</MultiMergeTfShellHintPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MultiMerge._2026</RootNamespace>
+    <AssemblyName>MultiMerge.2026</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.TeamFoundation.Controls">
+      <HintPath>$(MultiMergeTfShellHintPath)Microsoft.TeamFoundation.Controls.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TeamFoundation.VersionControl">
+      <HintPath>$(MultiMergeTfShellHintPath)Microsoft.VisualStudio.TeamFoundation.VersionControl.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.TeamFoundation.Client">
+      <HintPath>$(PkgMicrosoft_TeamFoundationServer_ExtendedClient)\lib\net472\Microsoft.TeamFoundation.Client.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Microsoft.TeamFoundation.VersionControl.Client">
+      <HintPath>$(PkgMicrosoft_TeamFoundationServer_ExtendedClient)\lib\net472\Microsoft.TeamFoundation.VersionControl.Client.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Compile Include="..\MultiMerge.2022\frmMerge.cs">
+      <Link>frmMerge.cs</Link>
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="..\MultiMerge.2022\MultiMerge.Package.cs">
+      <Link>MultiMerge.Package.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="VSPackage.resx">
+      <MergeWithCTO>true</MergeWithCTO>
+      <ManifestResourceName>VSPackage</ManifestResourceName>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\MultiMerge.2022\Key.snk">
+      <Link>Key.snk</Link>
+    </None>
+    <None Include="source.extension.vsixmanifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <VSCTCompile Include="..\MultiMerge.2022\MultiMerge.vsct">
+      <Link>MultiMerge.vsct</Link>
+      <ResourceName>Menus.ctmenu</ResourceName>
+      <SubType>Designer</SubType>
+    </VSCTCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\MultiMerge.2022\Package.png">
+      <Link>Package.png</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="..\MultiMerge.2022\Preview.png">
+      <Link>Preview.png</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Resource Include="..\MultiMerge.2022\Resource\VSPackage1.ico">
+      <Link>Resource\VSPackage1.ico</Link>
+    </Resource>
+    <Resource Include="..\MultiMerge.2022\Resource\Package.ico">
+      <Link>Resource\Package.ico</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Resource>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.0">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.4.5">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 4.5</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="20.256.2" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.14.40265" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2139" GeneratePathProperty="true">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="..\MultiMergeShared\MultiMergeShared.projitems" Label="Shared" />
+  <PropertyGroup>
+    <UseCodebase>true</UseCodebase>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+  <Import Project="$(PkgMicrosoft_VSSDK_BuildTools)\tools\VSSDK\Microsoft.VsSDK.targets" Condition="'$(PkgMicrosoft_VSSDK_BuildTools)' != '' And !Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+  <Target Name="MultiMergeWarnTfShellHintPath" BeforeTargets="PrepareForBuild">
+    <Warning Condition="'$(MultiMergeTfShellFromHost)' != 'true'"
+             Text="MultiMerge.2026: Team Explorer TF assemblies not found under VSInstallRoot ('$(VSInstallRoot)'). Using '$(MSBuildThisFileDirectory)Assemblies'. Build from a Visual Studio Developer Command Prompt (or install Azure DevOps / TFVC workload) so shell DLL versions match your IDE." />
+  </Target>
+  <Target Name="MultiMergeDedupeTfReferencePaths" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.Filename)' == 'Microsoft.TeamFoundation.Client' And !$([System.String]::Copy('%(ReferencePath.Identity)').ToLowerInvariant().Contains('microsoft.teamfoundationserver.extendedclient'))" />
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.Filename)' == 'Microsoft.TeamFoundation.VersionControl.Client' And !$([System.String]::Copy('%(ReferencePath.Identity)').ToLowerInvariant().Contains('microsoft.teamfoundationserver.extendedclient'))" />
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.Filename)' == 'Microsoft.VisualStudio.TeamFoundation.VersionControl' And ($([System.String]::Copy('%(ReferencePath.Identity)').ToLowerInvariant().Contains('publicassemblies')) Or $([System.String]::Copy('%(ReferencePath.Identity)').ToLowerInvariant().Contains('referenceassemblies')) Or $([System.String]::Copy('%(ReferencePath.Identity)').ToLowerInvariant().Contains('vssdk')))" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/MultiMerge.2026/VSPackage.resx
+++ b/MultiMerge.2026/VSPackage.resx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="110" xml:space="preserve">
+    <value>Merge multiple changesets</value>
+  </data>
+  <data name="112" xml:space="preserve">
+    <value>This extension is used to find and merge changesets that contains a specific comment.</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\MultiMerge.2022\Resource\Package.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="1110" xml:space="preserve">
+    <value>VSPackage1 Extension</value>
+  </data>
+  <data name="1112" xml:space="preserve">
+    <value>VSPackage1 Visual Stuido Extension Detailed Info</value>
+  </data>
+  <data name="1400" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\MultiMerge.2022\Resource\VSPackage1.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>

--- a/MultiMerge.2026/source.extension.vsixmanifest
+++ b/MultiMerge.2026/source.extension.vsixmanifest
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+    <Metadata>
+        <Identity Id="MultiMerge.2026.Jesusfan.7c2a9f11-4d8e-4b0a-9e1f-3a5b6c7d8e9f" Version="1.1.17.1" Language="en-US" Publisher="Jesusfan" />
+        <DisplayName>MultiMerge.2026</DisplayName>
+        <Description xml:space="preserve">Improves TFS merge experience by allowing merge of cherry picked changesets, easy baseless merges and power search &amp; merge changesets functionality (VS 2022 and newer)</Description>
+        <GettingStartedGuide>https://marketplace.visualstudio.com/items?itemName=Jesusfan.MultiMerge2019</GettingStartedGuide>
+        <Icon>Package.png</Icon>
+        <PreviewImage>Preview.png</PreviewImage>
+        <Tags>merge,tfs,multiple,changeset,changesets,tfvc</Tags>
+    </Metadata>
+    <Installation>
+      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
+        <ProductArchitecture>arm64</ProductArchitecture>
+      </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+        <Dependency Id="Microsoft.VisualStudio.MPF.16.0" DisplayName="Visual Studio MPF 16.0" d:Source="Installed" Version="[17.0,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
+</PackageManifest>

--- a/MultiMerge.sln
+++ b/MultiMerge.sln
@@ -1,12 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.32210.238
+# Visual Studio Version 18
+VisualStudioVersion = 18.2.11430.68 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiMerge.2017", "MultiMerge.2017\MultiMerge.2017.csproj", "{51AD2EA0-E551-4233-92B4-C4631BBFEC09}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiMerge.2017.Test", "MultiMerge.2017.Test\MultiMerge.2017.Test.csproj", "{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}"
-EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "MultiMergeShared", "MultiMergeShared\MultiMergeShared.shproj", "{3A61DB71-DE2D-434C-B914-C61DAEBB3C0E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiMerge.2019", "MultiMerge.2019\MultiMerge.2019.csproj", "{CCFDEA6D-5765-417A-B303-BC63A2EFD0A1}"
@@ -20,13 +16,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solution items", "solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiMerge.2022", "MultiMerge.2022\MultiMerge.2022.csproj", "{B57D24A3-DADB-4472-BED4-F7E8D60496BE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiMerge.2026", "MultiMerge.2026\MultiMerge.2026.csproj", "{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		MultiMergeShared\MultiMergeShared.projitems*{3a61db71-de2d-434c-b914-c61daebb3c0e}*SharedItemsImports = 13
-		MultiMergeShared\MultiMergeShared.projitems*{51ad2ea0-e551-4233-92b4-c4631bbfec09}*SharedItemsImports = 4
-		MultiMergeShared\MultiMergeShared.projitems*{b57d24a3-dadb-4472-bed4-f7e8d60496be}*SharedItemsImports = 4
-		MultiMergeShared\MultiMergeShared.projitems*{ccfdea6d-5765-417a-b303-bc63a2efd0a1}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
@@ -34,22 +26,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{51AD2EA0-E551-4233-92B4-C4631BBFEC09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{51AD2EA0-E551-4233-92B4-C4631BBFEC09}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{51AD2EA0-E551-4233-92B4-C4631BBFEC09}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{51AD2EA0-E551-4233-92B4-C4631BBFEC09}.Debug|x86.Build.0 = Debug|Any CPU
-		{51AD2EA0-E551-4233-92B4-C4631BBFEC09}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{51AD2EA0-E551-4233-92B4-C4631BBFEC09}.Release|Any CPU.Build.0 = Release|Any CPU
-		{51AD2EA0-E551-4233-92B4-C4631BBFEC09}.Release|x86.ActiveCfg = Release|Any CPU
-		{51AD2EA0-E551-4233-92B4-C4631BBFEC09}.Release|x86.Build.0 = Release|Any CPU
-		{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}.Debug|x86.Build.0 = Debug|Any CPU
-		{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}.Release|x86.ActiveCfg = Release|Any CPU
-		{AA4EC68F-4EEC-4144-9549-B3A76CDA81E6}.Release|x86.Build.0 = Release|Any CPU
 		{CCFDEA6D-5765-417A-B303-BC63A2EFD0A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CCFDEA6D-5765-417A-B303-BC63A2EFD0A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CCFDEA6D-5765-417A-B303-BC63A2EFD0A1}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -66,11 +42,25 @@ Global
 		{B57D24A3-DADB-4472-BED4-F7E8D60496BE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B57D24A3-DADB-4472-BED4-F7E8D60496BE}.Release|x86.ActiveCfg = Release|x86
 		{B57D24A3-DADB-4472-BED4-F7E8D60496BE}.Release|x86.Build.0 = Release|x86
+		{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}.Debug|x86.ActiveCfg = Debug|x86
+		{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}.Debug|x86.Build.0 = Debug|x86
+		{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}.Release|x86.ActiveCfg = Release|x86
+		{A91C4F88-2E6D-4B1A-9C0F-8D7E6F5A4B3C}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0851386F-84E0-4278-AB2E-47A64A04022D}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		MultiMergeShared\MultiMergeShared.projitems*{3a61db71-de2d-434c-b914-c61daebb3c0e}*SharedItemsImports = 13
+		MultiMergeShared\MultiMergeShared.projitems*{a91c4f88-2e6d-4b1a-9c0f-8d7e6f5a4b3c}*SharedItemsImports = 4
+		MultiMergeShared\MultiMergeShared.projitems*{b57d24a3-dadb-4472-bed4-f7e8d60496be}*SharedItemsImports = 4
+		MultiMergeShared\MultiMergeShared.projitems*{ccfdea6d-5765-417a-b303-bc63a2efd0a1}*SharedItemsImports = 4
 	EndGlobalSection
 EndGlobal

--- a/MultiMergeShared/MergeUI.cs
+++ b/MultiMergeShared/MergeUI.cs
@@ -2,12 +2,17 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using EnvDTE;
+using EnvDTE80;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.TeamFoundation.VersionControl.Client;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TeamFoundation.VersionControl;
 using MultiMergeShared;
@@ -92,23 +97,69 @@ namespace MultiMerge
         /// <summary>
         /// Initializes a new instance of the <see cref="MergeUI"/> class, via Source Control Explorer.
         /// </summary>
-        public MergeUI(VersionControlExt versionControl, ITeamExplorer teamExplorer, ILogger logger) : this(logger)
+        public MergeUI(VersionControlExt versionControl, ITeamExplorer teamExplorer, ILogger logger, DTE2 solutionDte = null) : this(logger)
         {
-            this._teamExplorer = teamExplorer;
-            this.versionControlExt = versionControl;
-            this._versionControlServer = this.versionControlExt.Explorer.Workspace.VersionControlServer;
-            _workspace = this.versionControlExt.Explorer.Workspace;
-            this.txtBasePath.Text = this.versionControlExt.Explorer.CurrentFolderItem.SourceServerPath;
-            this.FromDatePicker.Value = DateTime.Now - new TimeSpan(28, 0, 0, 0);
-            this.ToDatePicker.Value = DateTime.Now;
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _teamExplorer = teamExplorer;
+            versionControlExt = versionControl ?? throw new InvalidOperationException(
+                "Team Foundation version control is not available in this Visual Studio session.");
+
+            _workspace = TryGetWorkspace(versionControlExt);
+            if (_workspace == null)
+                throw new InvalidOperationException("No TFVC workspace is available for the current solution or selection.");
+
+            _versionControlServer = _workspace.VersionControlServer;
+            if (_versionControlServer == null)
+                throw new InvalidOperationException("The version control server is not available.");
+
+            var basePath = TryResolveInitialServerPath(versionControlExt, solutionDte);
+            if (string.IsNullOrWhiteSpace(basePath))
+                throw new InvalidOperationException("Could not resolve a TFVC server path from Source Control Explorer or the open solution.");
+
+            txtBasePath.Text = basePath;
+            FromDatePicker.Value = DateTime.Now - new TimeSpan(28, 0, 0, 0);
+            ToDatePicker.Value = DateTime.Now;
             lblStatus.Text = string.Empty;
+        }
+
+        private static Workspace TryGetWorkspace(VersionControlExt versionControl)
+        {
+            if (versionControl?.Explorer?.Workspace != null)
+                return versionControl.Explorer.Workspace;
+            // SolutionWorkspace is often COM / object-typed; keep everything on object so we never bind dynamic.GetValue.
+            object swObj = versionControl?.SolutionWorkspace;
+            if (swObj == null) return null;
+            var prop = swObj.GetType().GetProperty("Workspace", BindingFlags.Instance | BindingFlags.Public);
+            return prop?.GetValue(swObj, null) as Workspace;
+        }
+
+        private string TryResolveInitialServerPath(VersionControlExt vc, DTE2 dte)
+        {
+            var folder = vc.Explorer?.CurrentFolderItem;
+            if (!string.IsNullOrWhiteSpace(folder?.SourceServerPath))
+                return folder.SourceServerPath.Trim();
+
+            if (dte?.Solution != null && !string.IsNullOrEmpty(dte.Solution.FullName))
+            {
+                try
+                {
+                    var solDir = Path.GetDirectoryName(dte.Solution.FullName);
+                    if (!string.IsNullOrEmpty(solDir) && Directory.Exists(solDir) && _workspace != null)
+                        return _workspace.GetServerItemForLocalItem(solDir);
+                }
+                catch
+                {
+                    // continue to return null
+                }
+            }
+            return null;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MergeUI"/> class, via History
         /// </summary>
         public MergeUI(VersionControlExt versionControl, ITeamExplorer teamExplorer, ILogger logger,
-            string path, List<int> changeSetids) : this(versionControl, teamExplorer, logger)
+            string path, List<int> changeSetids) : this(versionControl, teamExplorer, logger, null)
         {
             txtBasePath.Text = path;
             OptionsGroupBox.Visible = false;


### PR DESCRIPTION
- Add MultiMerge.2026 project with forward compatibility for VS 2026

- Update solution to include new 2026 project and remove 2017 projects

- Enhance MultiMergeShared/MergeUI.cs with improved TFVC workspace resolution and DTE integration

- Update linked source files in MultiMerge.2022 to support new DTE2 parameter

This enables MultiMerge to work with Visual Studio 2026 while maintaining backward compatibility through existing projects.

Made-with: Cursor